### PR TITLE
Adds Giscus comment feature

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,6 +63,20 @@ params:
     # Maths typesetting
     math: true
 
+    comments: true
+    giscus:
+      repo: arthurgousset/website
+      repoID: MDEwOlJlcG9zaXRvcnk0MDM2MzcwMzE=
+      category: Comments
+      categoryID: DIC_kwDOGA8DJ84CdHsV
+      mapping: pathname
+      inputPosition: top
+      theme: preferred_color_scheme
+      lang: en
+      data-loading: lazy
+      crossorigin: anonymous
+      data-emit-metadata: 0
+
     # Profile Mode
     profileMode:
         enabled: true

--- a/config.yml
+++ b/config.yml
@@ -73,9 +73,6 @@ params:
       inputPosition: top
       theme: preferred_color_scheme
       lang: en
-      data-loading: lazy
-      crossorigin: anonymous
-      data-emit-metadata: 0
 
     # Profile Mode
     profileMode:

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,19 @@
+{{- if isset .Site.Params "giscus" -}}
+  {{- if and (isset .Site.Params.giscus "repo") (not (eq .Site.Params.giscus.repo "" )) (eq (.Params.disable_comments | default false) false) -}}
+  <script src="https://giscus.app/client.js"
+    data-repo="{{ .Site.Params.giscus.repo }}"
+    data-repo-id="{{ .Site.Params.giscus.repoID }}"
+    data-category="{{ .Site.Params.giscus.category }}"
+    data-category-id="{{ .Site.Params.giscus.categoryID }}"
+    data-mapping="{{ default "pathname" .Site.Params.giscus.mapping }}"
+    data-reactions-enabled="{{ default "1" .Site.Params.giscus.reactionsEnabled }}"
+    data-emit-metadata="{{ default "0" .Site.Params.giscus.emitMetadata }}"
+    data-input-position="{{ default "bottom" .Site.Params.giscus.inputPosition }}"
+    data-theme="{{ default "light" .Site.Params.giscus.theme }}"
+    data-lang="{{ default "en" .Site.Params.giscus.lang }}"
+    data-loading="{{ default "lazy" .Site.Params.giscus.loading }}"
+    crossorigin="anonymous"
+    async>
+  </script>
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Descriptions

Adds a comment section powered by Github Discussions. This feature is powered by [Giscus.app](https://giscus.app/).

<img width="550" alt="image" src="https://github.com/arthurgousset/website/assets/46296830/40b383c8-6675-471b-aad1-0c1bba03b7aa">

## References

- "[From Disqus to Giscus](https://gilbertdev.net/posts/2023/02/from-disqus-to-giscus/)" ([Nicholas Gilbert Blog](https://gilbertdev.net/)), this has instructions for configuring Giscus in Hugo sites with the PaperMod theme
- [Using giscus for comments in Hugo](https://cdwilson.dev/articles/using-giscus-for-comments-in-hugo/) ([Chris Wilson](https://cdwilson.dev/)), this has instructions for configuring Giscus in Hugo sites.

## Test

Tested locally and in preview build.