### PR TITLE
Enables line numbers, hyperlinks, and Github Dark mode for syntax highlighting

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -148,10 +148,10 @@ outputs:
 
 markup:
   highlight:
-    anchorLineNos: true
+    # anchorLineNos: true
     codeFences: true
     guessSyntax: true
-    lineNos: true
+    # lineNos: true
     # noClasses: false
     style: github-dark
     # style: rrt

--- a/config.yml
+++ b/config.yml
@@ -148,12 +148,12 @@ outputs:
 
 markup:
   highlight:
-    # anchorLineNos: true
+    anchorLineNos: true
     codeFences: true
     guessSyntax: true
-    lineNos: false
+    lineNos: true
     # noClasses: false
-    style: dracula
+    style: github-dark
     # style: rrt
     # style: paraiso-dark
     # style: native


### PR DESCRIPTION
Change how code blocks are rendered:
- enables line numbers that can be anchored (as hyperlinks)
- sets syntax highlighting to Github Dark mode